### PR TITLE
Do not consider unused links

### DIFF
--- a/bosh_template_go.go
+++ b/bosh_template_go.go
@@ -57,6 +57,8 @@ if $0 == __FILE__
 	links = []
 	if context_hash['properties'] && context_hash['properties']['bosh_containerization'] && context_hash['properties']['bosh_containerization']['consumes']
 		context_hash['properties']['bosh_containerization']['consumes'].each_pair do |name, link|
+			next if link['instances'].empty?
+
 			instances = []
 			link['instances'].each do |link_instance|
 				instances << Bosh::Template::Test::InstanceSpec.new(


### PR DESCRIPTION
This messes up the `if_link` helper in the `bosh-template` lib which only checks if such a link property exists and if it contains an `instances` field. Even if the `instances` array is empty `if_link` evaluates to true which may lead to unresolved properties later on.

**Note**: I was struggling to write a test case for this change because somehow the `if_link` block (and also the `else` block) were never rendered for some unknown reason.