### PR TITLE
Require minimal version(>=2.2.1) bosh-template

### DIFF
--- a/bosh_template_go.go
+++ b/bosh_template_go.go
@@ -17,6 +17,7 @@ const (
 	rbClassFileName               = "bosh_erb_renderer.rb"
 	evaluationContextYAMLFileName = "evaluation_context.yaml"
 	instanceInfoYAMLFileName      = "instance_info.yaml"
+	requiredVersion               = ">=2.2.1"
 )
 
 var (
@@ -143,12 +144,12 @@ func checkRubyAvailable() error {
 }
 
 func checkBOSHTemplateGemAvailable() error {
-	cmd := exec.Command(RubyGemBinary, "list", "-i", "bosh-template")
+	cmd := exec.Command(RubyGemBinary, "list", "-i", "bosh-template", "-v", requiredVersion)
 	outputBytes, err := cmd.CombinedOutput()
 
 	if err != nil {
 		output := string(outputBytes)
-		return errors.Wrapf(err, "rendering BOSH templates requires the bosh-template ruby gem, please install it: %s ", output)
+		return errors.Wrapf(err, "rendering BOSH templates requires the bosh-template(%s) ruby gem, please install it: %s ", requiredVersion, output)
 	}
 
 	return nil

--- a/bosh_template_go_test.go
+++ b/bosh_template_go_test.go
@@ -98,7 +98,7 @@ func TestNoGem(t *testing.T) {
 
 	// Assert
 	assert.Error(err)
-	assert.Contains(err.Error(), "rendering BOSH templates requires the bosh-template ruby gem")
+	assert.Contains(err.Error(), "rendering BOSH templates requires the bosh-template")
 }
 
 func TestRenderOK(t *testing.T) {


### PR DESCRIPTION
[#168103005](https://www.pivotaltracker.com/story/show/168103005)

Gem supports a `--version` option to specify minimal version of installed gem(If I had v2.2.1):
```
bjxzi$ gem list bosh-template -i -v ">=1.2.3"
true
bjxzi$ gem list bosh-template -i -v ">=2.2.1"
true
bjxzi$ gem list bosh-template -i -v ">=2.2.2"
false
```